### PR TITLE
artifact version fixed from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following to your `pom.xml`:
     <dependency>
         <groupId>com.github.strikerx3</groupId>
         <artifactId>jxinput</artifactId>
-        <version>1.0</version>    <!-- Use any released version, commit hash or branch-SNAPSHOT here -->
+        <version>1.0.0</version>    <!-- Use any released version, commit hash or branch-SNAPSHOT here -->
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
The version supplied by the example is not correct.
It may confuse some people because it just does not work when you copy and paste.